### PR TITLE
fix(T006): move notice banner, guard list pages against bad responses

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -14,17 +14,6 @@ function Home() {
 
   return (
     <div>
-      <div className="m-auto p-3 md:p-4 max-w-11/12 shadow bg-yellow-100 text-base md:text-lg border-l-4 border-yellow-500">
-        <div className="font-bold">サーバー移行のお知らせ</div>
-        <p>
-          このサイトは旧 <code>judge.tqk.blue</code> から{' '}
-          <code>qkjudge.kisen.one</code> に移行しました。
-          旧サーバーのアカウントは引き継いでいないため、{' '}
-          <strong>お手数ですが再度ユーザー登録をお願いします</strong>
-          。過去の提出は提出一覧の末尾に <code>[legacy]</code>{' '}
-          として閲覧のみ可能です。
-        </p>
-      </div>
       <div className="max-w-full bg-local p-16 md:p-64 bg-gradient-to-bl from-heroyellow-100 to-herocyan-100 text-center">
         <div className="text-xl">
           <Typography
@@ -53,6 +42,21 @@ function Home() {
         <div className="text-md md:text-2xl m-1 font-jp text-gray-500">
           <p>競技プログラミングの</p>
           <p>問題が解けるサイトです。</p>
+        </div>
+      </div>
+      <div className="my-5 bg-local">
+        <div className="m-auto p-3 md:p-4 max-w-11/12 shadow bg-yellow-100 border-l-4 border-yellow-500 text-base md:text-lg">
+          <div className="text-xl md:text-2xl font-bold mb-1">
+            サーバー移行のお知らせ
+          </div>
+          <p>
+            このサイトは旧 <code>judge.tqk.blue</code> から{' '}
+            <code>qkjudge.kisen.one</code> に移行しました。
+            旧サーバーのアカウントは引き継いでいないため、{' '}
+            <strong>お手数ですが再度ユーザー登録をお願いします</strong>
+            。過去の提出は提出一覧の末尾に <code>[legacy]</code>{' '}
+            として閲覧のみ可能です。
+          </p>
         </div>
       </div>
       <div className="my-5 bg-local">

--- a/src/components/pages/Problems.tsx
+++ b/src/components/pages/Problems.tsx
@@ -35,12 +35,14 @@ function Problems() {
     axios
       .get<GetProblemsResponse>(`${api}/problems`, { withCredentials: true })
       .then((res) => {
-        setProblems(res.data.problems)
+        // 想定外レスポンス (env 誤設定で SPA fallback の HTML が返る等) でも
+        // クラッシュさせずに空表示で済むようにガードする。
+        setProblems(res.data?.problems ?? [])
         setLoading(false)
       })
       .catch((err) => {
         console.log(err)
-        setLoading(true)
+        setLoading(false)
       })
   }, [user])
 

--- a/src/components/pages/Submissions.tsx
+++ b/src/components/pages/Submissions.tsx
@@ -80,7 +80,7 @@ function Submissions() {
         signal: controller.signal
       })
       .then((res) => {
-        setLegacyPagesNum(res.data.pages_number)
+        setLegacyPagesNum(res.data?.pages_number ?? 0)
       })
       .catch((err) => {
         if (axios.isCancel(err)) return
@@ -110,9 +110,12 @@ function Submissions() {
         })
         .then((res) => {
           setLoading(false)
-          setNewPagesNum(res.data.pages_number)
+          setNewPagesNum(res.data?.pages_number ?? 0)
           setRows(
-            res.data.submissions.map((s) => ({ ...s, isLegacy: false }))
+            (res.data?.submissions ?? []).map((s) => ({
+              ...s,
+              isLegacy: false
+            }))
           )
         })
         .catch((err) => {
@@ -129,9 +132,12 @@ function Submissions() {
         )
         .then((res) => {
           setLoading(false)
-          setLegacyPagesNum(res.data.pages_number)
+          setLegacyPagesNum(res.data?.pages_number ?? 0)
           setRows(
-            res.data.submissions.map((s) => ({ ...s, isLegacy: true }))
+            (res.data?.submissions ?? []).map((s) => ({
+              ...s,
+              isLegacy: true
+            }))
           )
         })
         .catch((err) => {


### PR DESCRIPTION
## 背景
PR #8 の merge 後、staging (\`qkjudge-stg.kisen.one\`) で \`/problems\` が画面真っ白、\`/submissions\` の表が空になっていた。

原因は Cloudflare Pages の Preview env vars の value に \`VITE_API_URL=https://qkjudge-api-stg.kisen.one\` (key 接頭辞付き) を貼ってしまっていたこと。bundle 内で \`const a = \"VITE_API_URL=https://qkjudge-api-stg.kisen.one\"\` となり、\`axios.get(\\\`\${a}/problems\\\`)\` のリクエスト URL が invalid → ブラウザは相対扱いで \`qkjudge-stg.kisen.one/...\` を叩き、Cloudflare Pages の SPA fallback で index.html が返る → \`res.data.problems\` が undefined → render 中に \`.map()\` で TypeError。

env を正しく直せばコード変更なしで動くが、再発防止と Home デザイン要望をまとめて対応する。

## 変更
1. **Home**: サーバー移行のお知らせバナーを最上部からヒーロー直下 (WIP カードの上) に移動。WIP カードと揃えた外側構造 (\`my-5 bg-local\` + \`max-w-11/12\`) にして見出し / 余白も調整。
2. **Problems**: \`.catch\` 内の \`setLoading(true)\` typo を \`false\` に修正 (元コードの bug)。
3. **Problems / Submissions**: \`res.data?.problems ?? []\` / \`res.data?.submissions ?? []\` / \`pages_number ?? 0\` で防御。env 誤設定で SPA fallback の HTML が axios resolve として渡ってきても、画面真っ白ではなく空表示で済む。

## ユーザー側手作業 (out-of-band; この PR と並行で確実に直す必要あり)
Cloudflare Pages dashboard → qkjudge-ui project → Settings → Environment variables:
- Production / Preview とも key=\`VITE_API_URL\`、value 欄に **\`VITE_API_URL=\` プレフィクスを含めず** URL だけを入れる:
  - Production value: \`https://qkjudge-api.kisen.one\`
  - Preview value:    \`https://qkjudge-api-stg.kisen.one\`

## 検証
- このブランチに対応する Cloudflare Pages preview deploy で \`/problems\`, \`/submissions\`, \`/legacy/submissions/{id}\` が動くこと
- dev へマージ後、\`qkjudge-stg.kisen.one\` で同じ動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)